### PR TITLE
Disable cache for binaries and play.html

### DIFF
--- a/main.go
+++ b/main.go
@@ -58,12 +58,24 @@ func main() {
 		go hub.Run()
 	}
 
-	//http.Handle("/", httpfileserver.New("/", "public/"))
+	http.HandleFunc("/index.wasm", HandlerWasm)
+	http.HandleFunc("/index.js", HandlerJs)
+	http.HandleFunc("/play.html", HandlerPlay)
 	http.Handle("/", http.FileServer(http.Dir("public/")))
-	//http.HandleFunc("/", Handler)
 	log.Fatal(http.ListenAndServe(":" + port, nil))
 }
 
-/*func Handler(w http.ResponseWriter, r *http.Request) {
-	http.ServeFile(w, r, "index.html")
-}*/
+func HandlerWasm(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	http.ServeFile(w, r, "public/index.wasm")
+}
+
+func HandlerJs(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	http.ServeFile(w, r, "public/index.js")
+}
+
+func HandlerPlay(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	http.ServeFile(w, r, "public/play.html")
+}

--- a/public/play.html
+++ b/public/play.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>EasyRPG Player</title>
-  <link rel="stylesheet" href="play.css">
+  <link rel="stylesheet" href="play.css?modified=20211120">
   <style>
     :root {
       --color-gray: hsl(0, 0%, 55%);


### PR DESCRIPTION
This would keep people's binaries up-to-date, eliminating the need for clearing the cache every time there's an update to them.
If you modified some other file you can do as i did with play.css:
`<link rel="stylesheet" href="play.css?modified=20211120">`

index.wasm is about 7 mb though. I wonder if it's better for it to be cached? That's possible too, but if you updated it, you'd need to modify index.js like this:
`wasmBinaryFile="index.wasm?modified=xxxxxxxx"`